### PR TITLE
PlayerEntity: despawn even if still on the player list

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/entity/PlayerEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/entity/PlayerEntity.java
@@ -87,12 +87,6 @@ public class PlayerEntity extends LivingEntity {
     }
 
     @Override
-    public boolean despawnEntity(GeyserSession session) {
-        super.despawnEntity(session);
-        return !playerList; // don't remove from cache when still on playerlist
-    }
-
-    @Override
     public void spawnEntity(GeyserSession session) {
         if (geyserId == 1) return;
 


### PR DESCRIPTION
Fixes LibsDisguises not working, as it uses the same entity ID for the disguised entity and player. The player still appears on the player list.