### PR TITLE
Add proper ominous banner translation (#1692)

### DIFF
--- a/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/BannerTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/item/translators/BannerTranslator.java
@@ -45,7 +45,38 @@ import java.util.stream.Collectors;
 
 @ItemRemapper
 public class BannerTranslator extends ItemTranslator {
+    /**
+     * Holds what a Java ominous banner pattern looks like.
+     *
+     * Translating the patterns over to Bedrock does not work effectively, but Bedrock has a dedicated type for
+     * ominous banners that we set instead. This variable is used to detect Java ominous banner patterns, and apply
+     * the correct ominous banner pattern if Bedrock pulls the item from creative.
+     */
+    public static final ListTag OMINOUS_BANNER_PATTERN;
+
     private final List<ItemEntry> appliedItems;
+
+    static {
+        OMINOUS_BANNER_PATTERN = new ListTag("Patterns");
+        // Construct what an ominous banner is supposed to look like
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("mr", 9));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("bs", 8));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("cs", 7));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("bo", 8));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("ms", 15));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("hh", 8));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("mc", 8));
+        OMINOUS_BANNER_PATTERN.add(getPatternTag("bo", 15));
+    }
+
+    private static CompoundTag getPatternTag(String pattern, int color) {
+        StringTag patternType = new StringTag("Pattern", pattern);
+        IntTag colorTag = new IntTag("Color", color);
+        CompoundTag tag = new CompoundTag("");
+        tag.put(patternType);
+        tag.put(colorTag);
+        return tag;
+    }
 
     public BannerTranslator() {
         appliedItems = ItemRegistry.ITEM_ENTRIES.values()
@@ -62,7 +93,7 @@ public class BannerTranslator extends ItemTranslator {
      */
     public static NbtList<NbtMap> convertBannerPattern(ListTag patterns) {
         List<NbtMap> tagsList = new ArrayList<>();
-        for (com.github.steveice10.opennbt.tag.builtin.Tag patternTag : patterns.getValue()) {
+        for (Tag patternTag : patterns.getValue()) {
             NbtMap newPatternTag = getBedrockBannerPattern((CompoundTag) patternTag);
             if (newPatternTag != null) {
                 tagsList.add(newPatternTag);
@@ -134,7 +165,13 @@ public class BannerTranslator extends ItemTranslator {
             ListTag patterns = blockEntityTag.get("Patterns");
 
             NbtMapBuilder builder = itemData.getTag().toBuilder();
-            builder.put("Patterns", convertBannerPattern(patterns));
+            if (patterns.equals(OMINOUS_BANNER_PATTERN)) {
+                // Remove the current patterns and set the ominous banner type
+                builder.remove("Patterns");
+                builder.putInt("Type", 1);
+            } else {
+                builder.put("Patterns", convertBannerPattern(patterns));
+            }
 
             itemData = ItemData.of(itemData.getId(), itemData.getDamage(), itemData.getCount(), builder.build());
         }
@@ -151,7 +188,14 @@ public class BannerTranslator extends ItemTranslator {
         ItemStack itemStack = super.translateToJava(itemData, itemEntry);
 
         NbtMap nbtTag = itemData.getTag();
-        if (nbtTag.containsKey("Patterns", NbtType.COMPOUND)) {
+        if (nbtTag.containsKey("Type", NbtType.INT) && nbtTag.getInt("Type") == 1) {
+            // Ominous banner pattern
+            itemStack.getNbt().remove("Type");
+            CompoundTag blockEntityTag = new CompoundTag("BlockEntityTag");
+            blockEntityTag.put(OMINOUS_BANNER_PATTERN);
+
+            itemStack.getNbt().put(blockEntityTag);
+        } else if (nbtTag.containsKey("Patterns", NbtType.COMPOUND)) {
             List<NbtMap> patterns = nbtTag.getList("Patterns", NbtType.COMPOUND);
 
             CompoundTag blockEntityTag = new CompoundTag("BlockEntityTag");

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BannerBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/BannerBlockEntityTranslator.java
@@ -47,7 +47,13 @@ public class BannerBlockEntityTranslator extends BlockEntityTranslator implement
 
         if (tag.contains("Patterns")) {
             ListTag patterns = tag.get("Patterns");
-            builder.put("Patterns", BannerTranslator.convertBannerPattern(patterns));
+            if (patterns.equals(BannerTranslator.OMINOUS_BANNER_PATTERN)) {
+                // This is an ominous banner; don't try to translate the raw patterns (it doesn't translate correctly)
+                // and tell the Bedrock client that this is an ominous banner
+                builder.putInt("Type", 1);
+            } else {
+                builder.put("Patterns", BannerTranslator.convertBannerPattern(patterns));
+            }
         }
 
         if (tag.contains("CustomName")) {


### PR DESCRIPTION
The ominous banner is a separate banner type in Bedrock. If we detect the ominous banner pattern, then we set the ominous banner type in NBT. This process is also checked vice-versa, allowing the ominous banner to be pulled from the Bedrock creative menu.