### PR TITLE
Smoothpistons MERGE BOI (#47)

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>com.github.steveice10</groupId>
             <artifactId>mcprotocollib</artifactId>
-            <version>26201a4</version>
+            <version>e1db422</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/GeyserSession.java
@@ -115,6 +115,7 @@ public class GeyserSession implements CommandSender {
     private EntityCache entityCache;
     private EntityEffectCache effectCache;
     private InventoryCache inventoryCache;
+    private final PistonCache pistonCache;
     private WorldCache worldCache;
     private WindowCache windowCache;
     private final Int2ObjectMap<TeleportCache> teleportMap = new Int2ObjectOpenHashMap<>();
@@ -132,6 +133,7 @@ public class GeyserSession implements CommandSender {
      * Used for translating Bedrock block actions to Java entity actions.
      */
     private final Object2LongMap<Vector3i> itemFrameCache = new Object2LongOpenHashMap<>();
+
 
     @Setter
     private Vector2i lastChunkPosition = null;
@@ -332,6 +334,7 @@ public class GeyserSession implements CommandSender {
         this.entityCache = new EntityCache(this);
         this.effectCache = new EntityEffectCache();
         this.inventoryCache = new InventoryCache(this);
+        this.pistonCache = new PistonCache(this);
         this.worldCache = new WorldCache(this);
         this.windowCache = new WindowCache(this);
 
@@ -785,7 +788,7 @@ public class GeyserSession implements CommandSender {
 
     /**
      * Queue a packet to be sent to player.
-     * 
+     *
      * @param packet the bedrock packet from the NukkitX protocol lib
      */
     public void sendUpstreamPacket(BedrockPacket packet) {

--- a/connector/src/main/java/org/geysermc/connector/network/session/cache/PistonCache.java
+++ b/connector/src/main/java/org/geysermc/connector/network/session/cache/PistonCache.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.network.session.cache;
+
+import com.github.steveice10.mc.protocol.packet.ingame.client.player.ClientPlayerPositionPacket;
+import com.nukkitx.math.vector.Vector3d;
+import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.protocol.bedrock.packet.MoveEntityAbsolutePacket;
+import com.nukkitx.protocol.bedrock.packet.SetEntityMotionPacket;
+import it.unimi.dsi.fastutil.objects.Object2ObjectMaps;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import lombok.Getter;
+import lombok.Setter;
+import org.geysermc.connector.entity.player.SessionPlayerEntity;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.collision.CollisionManager;
+import org.geysermc.connector.network.translators.world.block.entity.PistonBlockEntity;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class PistonCache {
+    private final GeyserSession session;
+
+    private final Map<Vector3i, PistonBlockEntity> pistons = Object2ObjectMaps.synchronize(new Object2ObjectOpenHashMap<>());
+
+    @Getter @Setter
+    private Vector3d playerDisplacement = Vector3d.ZERO;
+    @Getter @Setter
+    private Vector3f playerMotion = Vector3f.ZERO;
+
+    /**
+     * Stores whether a player has/will collide with any moving blocks.
+     */
+    @Getter @Setter
+    private boolean playerCollided = false;
+
+    private long lastMotionPacket;
+
+    /**
+     * The square length of displacement to ignore when being launched by a slime block
+     */
+    private static final double SMALL_DISPLACEMENT = 0.25;
+    /**
+     * The number of milliseconds after a motion packet to still be considered in motion.
+     */
+    private static final double MOTION_TIMEOUT = 200;
+
+    private ScheduledFuture<?> updater;
+
+    public PistonCache(GeyserSession session) {
+        this.session = session;
+    }
+
+    public void update() {
+        resetPlayerMovement();
+
+        if (session.isClosed() || pistons.isEmpty()) {
+            updater.cancel(false);
+            return;
+        }
+
+        pistons.values().forEach(PistonBlockEntity::update);
+        pistons.entrySet().removeIf((entry) -> entry.getValue().isDone());
+
+        sendPlayerMovement();
+    }
+
+    public void resetPlayerMovement() {
+        playerDisplacement = Vector3d.ZERO;
+        playerCollided = false;
+        playerMotion = Vector3f.ZERO;
+    }
+
+    public void sendPlayerMovement() {
+        SessionPlayerEntity playerEntity = session.getPlayerEntity();
+        // Sending a movement packet cancels motion from slime blocks in the Y direction
+        if (!playerDisplacement.equals(Vector3d.ZERO) && playerMotion.getY() == 0) {
+            // Sending small movement packets also cancels all motion
+            // Not sending any movement packets when in motion causes players to get stuck in slime blocks
+            if (!isInMotion() || playerDisplacement.lengthSquared() > SMALL_DISPLACEMENT) {
+                CollisionManager collisionManager = session.getCollisionManager();
+                if (collisionManager.correctPlayerPosition()) {
+                    Vector3d position = Vector3d.from(collisionManager.getPlayerBoundingBox().getMiddleX(), collisionManager.getPlayerBoundingBox().getMiddleY() - (collisionManager.getPlayerBoundingBox().getSizeY() / 2), collisionManager.getPlayerBoundingBox().getMiddleZ());
+                    playerEntity.setPosition(position.toFloat(), true);
+                    // Using MoveEntityAbsolutePacket for teleporting seems to be smoother than MovePlayerPacket
+                    // It also keeps motion from slime blocks
+                    MoveEntityAbsolutePacket moveEntityPacket = new MoveEntityAbsolutePacket();
+                    moveEntityPacket.setRuntimeEntityId(playerEntity.getGeyserId());
+                    moveEntityPacket.setPosition(playerEntity.getPosition());
+                    moveEntityPacket.setRotation(playerEntity.getBedrockRotation());
+                    moveEntityPacket.setOnGround(playerEntity.isOnGround());
+                    moveEntityPacket.setTeleported(true);
+                    session.sendUpstreamPacket(moveEntityPacket);
+
+                    ClientPlayerPositionPacket playerPositionPacket = new ClientPlayerPositionPacket(playerEntity.isOnGround(), position.getX(), position.getY(), position.getZ());
+                    session.sendDownstreamPacket(playerPositionPacket);
+                }
+            }
+        }
+        if (!playerMotion.equals(Vector3f.ZERO)) {
+            lastMotionPacket = System.currentTimeMillis();
+
+            playerEntity.setMotion(playerMotion);
+            SetEntityMotionPacket setEntityMotionPacket = new SetEntityMotionPacket();
+            setEntityMotionPacket.setRuntimeEntityId(playerEntity.getGeyserId());
+            setEntityMotionPacket.setMotion(playerMotion);
+            session.sendUpstreamPacket(setEntityMotionPacket);
+        }
+    }
+
+    public PistonBlockEntity getPistonAt(Vector3i position) {
+        return pistons.get(position);
+    }
+
+    public void putPiston(PistonBlockEntity pistonBlockEntity) {
+        pistons.put(pistonBlockEntity.getPosition(), pistonBlockEntity);
+
+        if (updater == null || updater.isDone()) {
+            updater = session.getConnector().getGeneralThreadPool().scheduleAtFixedRate(this::update, 50, 50, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    public void clear() {
+        pistons.clear();
+    }
+
+    private boolean isInMotion() {
+        long timeSinceMotionPacket = System.currentTimeMillis() - lastMotionPacket;
+        return !playerMotion.equals(Vector3f.ZERO) || timeSinceMotionPacket < MOTION_TIMEOUT;
+    }
+
+    /**
+     * Check whether a movement packet should be canceled.
+     * This cancels packets when being pushed by a piston and when not recently launched by a slime block
+     * @return True if the packet should be canceled
+     */
+    public boolean shouldCancelMovement() {
+        return !isInMotion() && (!playerDisplacement.equals(Vector3d.ZERO) || playerCollided);
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockMovePlayerTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/bedrock/entity/player/BedrockMovePlayerTranslator.java
@@ -170,6 +170,11 @@ public class BedrockMovePlayerTranslator extends PacketTranslator<MovePlayerPack
                 Double.parseDouble(Float.toString(bedrockPosition.getZ())));
 
         if (session.getConnector().getConfig().isCacheChunks()) {
+            if (session.getPistonCache().shouldCancelMovement()) {
+                recalculatePosition(session);
+                return null;
+            }
+
             // With chunk caching, we can do some proper collision checks
             CollisionManager collisionManager = session.getCollisionManager();
             collisionManager.updatePlayerBoundingBox(position);

--- a/connector/src/main/java/org/geysermc/connector/network/translators/collision/BoundingBox.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/collision/BoundingBox.java
@@ -25,6 +25,7 @@
 
 package org.geysermc.connector.network.translators.collision;
 
+import com.nukkitx.math.vector.Vector3d;
 import lombok.*;
 
 @Data
@@ -44,9 +45,43 @@ public class BoundingBox {
         middleZ += z;
     }
 
-    public boolean checkIntersection(int offsetX, int offsetY, int offsetZ, BoundingBox otherBox) {
+    public void extend(double x, double y, double z) {
+        middleX += x / 2;
+        middleY += y / 2;
+        middleZ += z / 2;
+
+        sizeX += Math.abs(x);
+        sizeY += Math.abs(y);
+        sizeZ += Math.abs(z);
+    }
+
+    public boolean checkIntersection(double offsetX, double offsetY, double offsetZ, BoundingBox otherBox) {
         return (Math.abs((middleX + offsetX) - otherBox.getMiddleX()) * 2 < (sizeX + otherBox.getSizeX())) &&
                 (Math.abs((middleY + offsetY) - otherBox.getMiddleY()) * 2 < (sizeY + otherBox.getSizeY())) &&
                 (Math.abs((middleZ + offsetZ) - otherBox.getMiddleZ()) * 2 < (sizeZ + otherBox.getSizeZ()));
+    }
+
+    public Vector3d getIntersectionSize(double offsetX, double offsetY, double offsetZ, BoundingBox otherBox) {
+        if (!checkIntersection(offsetX, offsetY, offsetZ, otherBox)) {
+            return Vector3d.ZERO;
+        }
+        Vector3d offset = Vector3d.from(offsetX, offsetY, offsetZ);
+        Vector3d minIntersection = getMin().add(offset).max(otherBox.getMin());
+        Vector3d maxIntersection = getMax().add(offset).min(otherBox.getMax());
+        return maxIntersection.sub(minIntersection);
+    }
+
+    public Vector3d getMin() {
+        double x = middleX - sizeX / 2;
+        double y = middleY - sizeY / 2;
+        double z = middleZ - sizeZ / 2;
+        return Vector3d.from(x, y, z);
+    }
+
+    public Vector3d getMax() {
+        double x = middleX + sizeX / 2;
+        double y = middleY + sizeY / 2;
+        double z = middleZ + sizeZ / 2;
+        return Vector3d.from(x, y, z);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/collision/translators/BlockCollision.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/collision/translators/BlockCollision.java
@@ -151,4 +151,23 @@ public class BlockCollision {
         }
         return false;
     }
+
+    // TODO cache result
+    public BoundingBox getContainingBoundingBox() {
+        if (boundingBoxes.length == 0) {
+            return null;
+        } else if (boundingBoxes.length == 1) {
+            return boundingBoxes[0];
+        }
+        Vector3d minPos = Vector3d.from(1e6);
+        Vector3d maxPos = Vector3d.ZERO;
+        for (BoundingBox b : boundingBoxes) {
+            minPos = minPos.min(b.getMin());
+            maxPos = maxPos.max(b.getMax());
+        }
+
+        Vector3d size = maxPos.sub(minPos);
+        Vector3d middle = maxPos.add(minPos).div(2);
+        return new BoundingBox(middle.getX(), middle.getY(), middle.getZ(), size.getX(), size.getY(), size.getZ());
+    }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockValueTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/java/world/JavaBlockValueTranslator.java
@@ -37,8 +37,7 @@ import org.geysermc.connector.network.session.GeyserSession;
 import org.geysermc.connector.network.translators.PacketTranslator;
 import org.geysermc.connector.network.translators.Translator;
 import org.geysermc.connector.network.translators.world.block.entity.NoteblockBlockEntityTranslator;
-
-import java.util.concurrent.TimeUnit;
+import org.geysermc.connector.network.translators.world.block.entity.PistonBlockEntity;
 
 
 @Translator(packet = ServerBlockValuePacket.class)
@@ -60,16 +59,17 @@ public class JavaBlockValueTranslator extends PacketTranslator<ServerBlockValueP
         } else if (packet.getValue() instanceof NoteBlockValue) {
             NoteblockBlockEntityTranslator.translate(session, packet.getPosition());
         } else if (packet.getValue() instanceof PistonValue) {
-            PistonValueType type = (PistonValueType) packet.getType();
-
+            PistonValueType action = (PistonValueType) packet.getType();
+            PistonValue direction = (PistonValue) packet.getValue();
             // Unlike everything else, pistons need a block entity packet to convey motion
             // TODO: Doesn't register on chunk load; needs to be interacted with first
             Vector3i position = Vector3i.from(packet.getPosition().getX(), packet.getPosition().getY(), packet.getPosition().getZ());
-            if (type == PistonValueType.PUSHING) {
-                extendPiston(session, position, 0.0f, 0.0f);
-            } else {
-                retractPiston(session, position, 1.0f, 1.0f);
+            PistonBlockEntity blockEntity = session.getPistonCache().getPistonAt(position);
+            if (blockEntity == null) {
+                blockEntity = new PistonBlockEntity(session, position, direction);
+                session.getPistonCache().putPiston(blockEntity);
             }
+            blockEntity.setAction(action);
         } else if (packet.getValue() instanceof MobSpawnerValue) {
             blockEventPacket.setEventType(1);
             session.sendUpstreamPacket(blockEventPacket);
@@ -111,66 +111,5 @@ public class JavaBlockValueTranslator extends PacketTranslator<ServerBlockValueP
             blockEntityPacket.setData(builder.build());
             session.sendUpstreamPacket(blockEntityPacket);
         }
-    }
-
-    /**
-     * Emulating a piston extending
-     * @param session GeyserSession
-     * @param position Block position
-     * @param progress How far the piston is
-     * @param lastProgress How far the piston last was
-     */
-    private void extendPiston(GeyserSession session, Vector3i position, float progress, float lastProgress) {
-        BlockEntityDataPacket blockEntityDataPacket = new BlockEntityDataPacket();
-        blockEntityDataPacket.setBlockPosition(position);
-        byte state = (byte) ((progress == 1.0f && lastProgress == 1.0f) ? 2 : 1);
-        blockEntityDataPacket.setData(buildPistonTag(position, progress, lastProgress, state));
-        session.sendUpstreamPacket(blockEntityDataPacket);
-        if (lastProgress != 1.0f) {
-            session.getConnector().getGeneralThreadPool().schedule(() ->
-                            extendPiston(session, position, (progress >= 1.0f) ? 1.0f : progress + 0.5f, progress),
-                    20, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    /**
-     * Emulate a piston retracting.
-     * @param session GeyserSession
-     * @param position Block position
-     * @param progress Current progress of piston
-     * @param lastProgress Last progress of piston
-     */
-    private void retractPiston(GeyserSession session, Vector3i position, float progress, float lastProgress) {
-        BlockEntityDataPacket blockEntityDataPacket = new BlockEntityDataPacket();
-        blockEntityDataPacket.setBlockPosition(position);
-        byte state = (byte) ((progress == 0.0f && lastProgress == 0.0f) ? 0 : 3);
-        blockEntityDataPacket.setData(buildPistonTag(position, progress, lastProgress, state));
-        session.sendUpstreamPacket(blockEntityDataPacket);
-        if (lastProgress != 0.0f) {
-            session.getConnector().getGeneralThreadPool().schedule(() ->
-                            retractPiston(session, position, (progress <= 0.0f) ? 0.0f : progress - 0.5f, progress),
-                    20, TimeUnit.MILLISECONDS);
-        }
-    }
-
-    /**
-     * Build a piston tag
-     * @param position Piston position
-     * @param progress Current progress of piston
-     * @param lastProgress Last progress of piston
-     * @param state
-     * @return Bedrock CompoundTag of piston
-     */
-    private NbtMap buildPistonTag(Vector3i position, float progress, float lastProgress, byte state) {
-        NbtMapBuilder builder = NbtMap.builder()
-                .putInt("x", position.getX())
-                .putInt("y", position.getY())
-                .putInt("z", position.getZ())
-                .putFloat("Progress", progress)
-                .putFloat("LastProgress", lastProgress)
-                .putString("id", "PistonArm")
-                .putByte("NewState", state)
-                .putByte("State", state);
-        return builder.build();
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockStateValues.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockStateValues.java
@@ -26,8 +26,11 @@
 package org.geysermc.connector.network.translators.world.block;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.steveice10.mc.protocol.data.game.world.block.value.PistonValue;
 import com.nukkitx.nbt.NbtMap;
 import it.unimi.dsi.fastutil.ints.*;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -45,6 +48,7 @@ public class BlockStateValues {
     private static final Int2IntMap NOTEBLOCK_PITCHES = new Int2IntOpenHashMap();
     private static final Int2BooleanMap IS_STICKY_PISTON = new Int2BooleanOpenHashMap();
     private static final Int2BooleanMap PISTON_VALUES = new Int2BooleanOpenHashMap();
+    private static final Object2IntMap<PistonValue> PISTON_HEADS = new Object2IntOpenHashMap<>();
     private static final Int2ByteMap SKULL_VARIANTS = new Int2ByteOpenHashMap();
     private static final Int2ByteMap SKULL_ROTATIONS = new Int2ByteOpenHashMap();
     private static final Int2IntMap SKULL_WALL_DIRECTIONS = new Int2IntOpenHashMap();
@@ -98,6 +102,22 @@ public class BlockStateValues {
             // True if extended, false if not
             PISTON_VALUES.put(javaBlockState, entry.getKey().contains("extended=true"));
             IS_STICKY_PISTON.put(javaBlockState, entry.getKey().contains("sticky"));
+            
+            if (entry.getKey().contains("head") && entry.getKey().contains("short=false")) {
+                if (entry.getKey().contains("down")) {
+                    PISTON_HEADS.put(PistonValue.DOWN, javaBlockState);
+                } else if (entry.getKey().contains("up")) {
+                    PISTON_HEADS.put(PistonValue.UP, javaBlockState);
+                } else if (entry.getKey().contains("south")) {
+                    PISTON_HEADS.put(PistonValue.SOUTH, javaBlockState);
+                } else if (entry.getKey().contains("west")) {
+                    PISTON_HEADS.put(PistonValue.WEST, javaBlockState);
+                } else if (entry.getKey().contains("north")) {
+                    PISTON_HEADS.put(PistonValue.NORTH, javaBlockState);
+                } else if (entry.getKey().contains("east")) {
+                    PISTON_HEADS.put(PistonValue.EAST, javaBlockState);
+                }       
+            }
             return;
         }
 
@@ -219,6 +239,17 @@ public class BlockStateValues {
 
     public static boolean isStickyPiston(int blockState) {
         return IS_STICKY_PISTON.get(blockState);
+    }
+
+    /**
+     * Get the Java Block State for a piston head for a specific direction
+     * This is used in PistonBlockEntity to get the BlockCollision for the piston head.
+     *
+     * @param direction Direction the piston head points in
+     * @return Block state for the piston head
+     */
+    public static int getPistonHead(PistonValue direction) {
+        return PISTON_HEADS.getOrDefault(direction, BlockTranslator.JAVA_AIR_ID);
     }
 
     /**

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/BlockTranslator.java
@@ -41,6 +41,7 @@ import java.io.InputStream;
 import java.util.*;
 
 public class BlockTranslator {
+    public static final NbtList<NbtMap> BLOCKS;
     /**
      * The Java block runtime ID of air
      */
@@ -70,6 +71,8 @@ public class BlockTranslator {
     public static final Int2DoubleMap JAVA_RUNTIME_ID_TO_HARDNESS = new Int2DoubleOpenHashMap();
     public static final Int2BooleanMap JAVA_RUNTIME_ID_TO_CAN_HARVEST_WITH_HAND = new Int2BooleanOpenHashMap();
     public static final Int2ObjectMap<String> JAVA_RUNTIME_ID_TO_TOOL_TYPE = new Int2ObjectOpenHashMap<>();
+    public static final Int2ObjectMap<String> JAVA_RUNTIME_ID_TO_PISTON_BEHAVIOR = new Int2ObjectOpenHashMap<>();
+    public static final Int2BooleanMap JAVA_RUNTIME_ID_TO_HAS_BLOCK_ENTITY = new Int2BooleanOpenHashMap();
 
     // The index of the collision data in collision.json
     public static final Int2IntMap JAVA_RUNTIME_ID_TO_COLLISION_INDEX = new Int2IntOpenHashMap();
@@ -84,6 +87,11 @@ public class BlockTranslator {
      */
     public static final int BEDROCK_RUNTIME_COMMAND_BLOCK_ID;
 
+    /**
+     * Runtime moving Block ID, used for blocks moved by pistons
+     */
+    public static int BEDROCK_RUNTIME_MOVING_BLOCK_ID;
+
     // For block breaking animation math
     public static final IntSet JAVA_RUNTIME_WOOL_IDS = new IntOpenHashSet();
     public static final int JAVA_RUNTIME_COBWEB_ID;
@@ -92,6 +100,9 @@ public class BlockTranslator {
     public static final int JAVA_RUNTIME_FURNACE_LIT_ID;
 
     public static final int JAVA_RUNTIME_SPAWNER_ID;
+
+    public static final int JAVA_RUNTIME_SLIME_BLOCK_ID;
+    public static final int JAVA_RUNTIME_HONEY_BLOCK_ID;
 
     private static final int BLOCK_STATE_VERSION = 17825808;
 
@@ -103,6 +114,7 @@ public class BlockTranslator {
         try (NBTInputStream nbtInputStream = new NBTInputStream(new DataInputStream(stream))) {
             NbtMap blockPalette = (NbtMap) nbtInputStream.readTag();
             blocksTag = (NbtList<NbtMap>) blockPalette.getList("blocks", NbtType.COMPOUND);
+            BLOCKS = blocksTag;
         } catch (Exception e) {
             throw new AssertionError("Unable to get blocks from runtime block states", e);
         }
@@ -139,6 +151,8 @@ public class BlockTranslator {
         int furnaceRuntimeId = -1;
         int furnaceLitRuntimeId = -1;
         int spawnerRuntimeId = -1;
+        int honeyBlockRuntimeId = -1;
+        int slimeBlockRuntimeId = -1;
         int uniqueJavaId = -1;
         Iterator<Map.Entry<String, JsonNode>> blocksIterator = blocks.fields();
         while (blocksIterator.hasNext()) {
@@ -171,6 +185,21 @@ public class BlockTranslator {
             JsonNode collisionIndexNode = entry.getValue().get("collision_index");
             if (hardnessNode != null) {
                 JAVA_RUNTIME_ID_TO_COLLISION_INDEX.put(javaRuntimeId, collisionIndexNode.intValue());
+            }
+
+            if (javaId.contains("obsidian") || javaId.contains("respawn_anchor")) {
+                // Override obsidian, crying_obsidian, and respawn_anchor to block piston movement
+                JAVA_RUNTIME_ID_TO_PISTON_BEHAVIOR.put(javaRuntimeId, "block");
+            } else {
+                JsonNode pistonBehaviorNode = entry.getValue().get("piston_behavior");
+                if (pistonBehaviorNode != null) {
+                    JAVA_RUNTIME_ID_TO_PISTON_BEHAVIOR.put(javaRuntimeId, pistonBehaviorNode.textValue());
+                }
+            }
+
+            JsonNode hasBlockEntityNode = entry.getValue().get("has_block_entity");
+            if (hasBlockEntityNode != null) {
+                JAVA_RUNTIME_ID_TO_HAS_BLOCK_ENTITY.put(javaRuntimeId, hasBlockEntityNode.booleanValue());
             }
 
             JAVA_ID_BLOCK_MAP.put(javaId, javaRuntimeId);
@@ -242,6 +271,12 @@ public class BlockTranslator {
             } else if (javaId.startsWith("minecraft:spawner")) {
                 spawnerRuntimeId = javaRuntimeId;
             }
+
+            if (javaId.equals("minecraft:honey_block")) {
+                honeyBlockRuntimeId = javaRuntimeId;
+            } else if (javaId.equals("minecraft:slime_block")) {
+                slimeBlockRuntimeId = javaRuntimeId;
+            }
         }
 
         if (cobwebRuntimeId == -1) {
@@ -279,12 +314,30 @@ public class BlockTranslator {
         }
         BEDROCK_AIR_ID = airRuntimeId;
 
-        // Loop around again to find all item frame runtime IDs
+        if (honeyBlockRuntimeId == -1) {
+            throw new AssertionError("Unable to find honey block in palette");
+        }
+        JAVA_RUNTIME_HONEY_BLOCK_ID = honeyBlockRuntimeId;
+
+        if (slimeBlockRuntimeId == -1) {
+            throw new AssertionError("Unable to find slime block in palette");
+        }
+        JAVA_RUNTIME_SLIME_BLOCK_ID = slimeBlockRuntimeId;
+
+        // Loop around again to find all item frame runtime IDs and movingBlock's runtime ID
+        int movingBlockId = -1;
         for (Object2IntMap.Entry<NbtMap> entry : blockStateOrderedMap.object2IntEntrySet()) {
             if (entry.getKey().getString("name").equals("minecraft:frame")) {
                 ITEM_FRAMES.put(entry.getKey(), entry.getIntValue());
+            } else if (entry.getKey().getString("name").equals("minecraft:movingBlock")) {
+                movingBlockId = entry.getIntValue();
             }
         }
+
+        if (movingBlockId == -1) {
+            throw new AssertionError("Unable to find moving block in palette");
+        }
+        BEDROCK_RUNTIME_MOVING_BLOCK_ID = movingBlockId;
     }
 
     private BlockTranslator() {

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/PistonBlockEntity.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/PistonBlockEntity.java
@@ -1,0 +1,728 @@
+/*
+ * Copyright (c) 2019-2020 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
+package org.geysermc.connector.network.translators.world.block.entity;
+
+import com.github.steveice10.mc.protocol.data.game.world.block.value.PistonValue;
+import com.github.steveice10.mc.protocol.data.game.world.block.value.PistonValueType;
+import com.google.common.collect.ImmutableList;
+import com.nukkitx.math.vector.Vector3d;
+import com.nukkitx.math.vector.Vector3f;
+import com.nukkitx.math.vector.Vector3i;
+import com.nukkitx.nbt.NbtMap;
+import com.nukkitx.nbt.NbtMapBuilder;
+import com.nukkitx.protocol.bedrock.packet.UpdateBlockPacket;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import lombok.Getter;
+import org.geysermc.connector.entity.type.EntityType;
+import org.geysermc.connector.network.session.GeyserSession;
+import org.geysermc.connector.network.translators.collision.BoundingBox;
+import org.geysermc.connector.network.translators.collision.CollisionManager;
+import org.geysermc.connector.network.translators.collision.CollisionTranslator;
+import org.geysermc.connector.network.translators.collision.translators.BlockCollision;
+import org.geysermc.connector.network.translators.collision.translators.SolidCollision;
+import org.geysermc.connector.network.translators.world.block.BlockStateValues;
+import org.geysermc.connector.network.translators.world.block.BlockTranslator;
+import org.geysermc.connector.utils.BlockEntityUtils;
+import org.geysermc.connector.utils.ChunkUtils;
+
+import java.util.*;
+
+public class PistonBlockEntity {
+    private final GeyserSession session;
+    @Getter
+    private final Vector3i position;
+    private final PistonValue orientation;
+    private final boolean sticky;
+
+    private PistonValueType action;
+
+    /**
+     * A map of attached block positions to Java ids.
+     */
+    private final Object2IntMap<Vector3i> attachedBlocks = new Object2IntOpenHashMap<>();
+    /**
+     * A flattened array of the positions of attached blocks, stored in XYZ order.
+     */
+    private int[] flattenedAttachedBlocks = new int[0];
+
+    /**
+     * The position of the piston head
+     */
+    private float progress = 0.0f;
+    private float lastProgress = 0.0f;
+
+    private static final NbtMap AIR_TAG = BlockTranslator.BLOCKS.get(BlockTranslator.BEDROCK_AIR_ID).getCompound("block");
+    private static final List<Vector3i> ALL_DIRECTIONS = ImmutableList.of(Vector3i.from(1, 0, 0), Vector3i.from(0, 1, 0), Vector3i.from(0, 0, 1), Vector3i.from(-1, 0, 0), Vector3i.from(0, -1, 0), Vector3i.from(0, 0, -1));
+
+    private static final BlockCollision SOLID_COLLISION = new SolidCollision(null);
+
+    private static final BoundingBox HONEY_BOUNDING_BOX;
+
+    static {
+        // Create a ~1 x ~0.5 x ~1 bounding box above the honey block
+        BlockCollision blockCollision = CollisionTranslator.getCollision(BlockTranslator.JAVA_RUNTIME_HONEY_BLOCK_ID, 0, 0, 0);
+        BoundingBox blockBoundingBox = blockCollision.getContainingBoundingBox();
+
+        double honeyHeight = blockBoundingBox.getMax().getY();
+        double boundingBoxHeight = 1.5 - honeyHeight;
+        HONEY_BOUNDING_BOX = new BoundingBox(0.5, honeyHeight + boundingBoxHeight / 2, 0.5, blockBoundingBox.getSizeX(), boundingBoxHeight, blockBoundingBox.getSizeZ());
+    }
+
+    public PistonBlockEntity(GeyserSession session, Vector3i position, PistonValue orientation) {
+        this.session = session;
+        this.position = position;
+        this.orientation = orientation;
+
+        if (session.getConnector().getConfig().isCacheChunks()) {
+            int blockId = session.getConnector().getWorldManager().getBlockAt(session, position);
+            sticky = BlockStateValues.isStickyPiston(blockId);
+            boolean extended = BlockStateValues.getPistonValues().get(blockId);
+            if (extended) {
+                this.action = PistonValueType.PUSHING;
+                this.progress = 1.0f;
+            } else {
+                this.action = PistonValueType.PULLING;
+                this.progress = 0.0f;
+            }
+            this.lastProgress = progress;
+        } else {
+            sticky = false;
+        }
+    }
+
+    /**
+     * Set whether the piston is pulling or pushing blocks
+     * @param action Pulling or Pushing
+     */
+    public void setAction(PistonValueType action) {
+        this.action = action;
+        if (action == PistonValueType.CANCELLED_MID_PUSH) {
+            // Immediately fully extend the piston
+            lastProgress = progress;
+            progress = 1.0f;
+        } else if (action == PistonValueType.PUSHING || (action == PistonValueType.PULLING && sticky)) {
+            // Blocks only move when pushing or pulling with sticky pistons
+            findAffectedBlocks();
+            removeBlocks();
+            createMovingBlocks();
+        }
+
+        BlockEntityUtils.updateBlockEntity(session, buildPistonTag(), position);
+
+        session.getPistonCache().resetPlayerMovement();
+        update();
+        session.getPistonCache().sendPlayerMovement();
+    }
+
+    /**
+     * Send a block entity data packets to update the position of the piston head
+     */
+    public void update() {
+        updateProgress();
+        correctPlayerPosition();
+        BlockEntityUtils.updateBlockEntity(session, buildPistonTag(), position);
+        if (!isDone()) {
+            if (action == PistonValueType.CANCELLED_MID_PUSH && attachedBlocks.size() > 0) {
+                finishMovingBlocks();
+                attachedBlocks.clear();
+                flattenedAttachedBlocks = new int[0];
+            }
+        } else {
+            if (action != PistonValueType.PUSHING) {
+                removePistonHead();
+            }
+            finishMovingBlocks();
+        }
+    }
+
+    private boolean isPistonHead(int blockId) {
+        String javaId = BlockTranslator.getJavaIdBlockMap().inverse().get(blockId);
+        return javaId.contains("piston_head");
+    }
+
+    /**
+     * Removes lingering piston heads
+     */
+    private void removePistonHead() {
+        Vector3i blockInFront = position.add(getDirectionOffset());
+        int blockId = session.getConnector().getWorldManager().getBlockAt(session, blockInFront);
+        if (isPistonHead(blockId)) {
+            ChunkUtils.updateBlock(session, BlockTranslator.JAVA_AIR_ID, blockInFront);
+        }
+    }
+
+    /**
+     * Find the blocks pushed, pulled, or broken by the piston
+     */
+    private void findAffectedBlocks() {
+        attachedBlocks.clear();
+        if (!session.getConnector().getConfig().isCacheChunks()) {
+            flattenPositions();
+            return;
+        }
+        Set<Vector3i> blocksChecked = new ObjectOpenHashSet<>();
+        Queue<Vector3i> blocksToCheck = new LinkedList<>();
+
+        Vector3i directionOffset = getDirectionOffset();
+        Vector3i movement = getMovement();
+        blocksChecked.add(position); // Don't check the piston itself
+        if (action == PistonValueType.PULLING) {
+            blocksChecked.add(position.add(directionOffset)); // Don't check the piston head
+            blocksToCheck.add(position.add(directionOffset.mul(2)));
+        } else if (action == PistonValueType.PUSHING) {
+            removePistonHead();
+            blocksToCheck.add(position.add(directionOffset));
+        }
+
+        boolean moveBlocks = true;
+        while (!blocksToCheck.isEmpty() && attachedBlocks.size() < 12) {
+            Vector3i blockPos = blocksToCheck.remove();
+            // Skip blocks we've already checked
+            if (blocksChecked.contains(blockPos)) {
+                continue;
+            }
+            blocksChecked.add(blockPos);
+            int blockId = session.getConnector().getWorldManager().getBlockAt(session, blockPos);
+            if (blockId == BlockTranslator.JAVA_AIR_ID) {
+                continue;
+            }
+            blocksChecked.add(blockPos);
+            if (canMoveBlock(blockId, action == PistonValueType.PUSHING)) {
+                attachedBlocks.put(blockPos, blockId);
+                if (isBlockSticky(blockId)) {
+                    // For honey blocks and slime blocks check the blocks adjacent to it
+                    for (Vector3i offset : ALL_DIRECTIONS) {
+                        // Only check blocks that aren't being pushed by the current block
+                        if (offset.equals(movement)) {
+                            continue;
+                        }
+                        Vector3i adjacentPos = blockPos.add(offset);
+                        // Ignore the piston block itself
+                        if (adjacentPos.equals(position)) {
+                            continue;
+                        }
+                        // Ignore the piston head
+                        if (action == PistonValueType.PULLING && position.add(directionOffset).equals(adjacentPos)) {
+                            continue;
+                        }
+                        int adjacentBlockId = session.getConnector().getWorldManager().getBlockAt(session, adjacentPos);
+                        if (adjacentBlockId != BlockTranslator.JAVA_AIR_ID && isBlockAttached(blockId, adjacentBlockId) && canMoveBlock(adjacentBlockId, false)) {
+                            // If it is another slime/honey block we need to check its adjacent blocks
+                            if (isBlockSticky(adjacentBlockId)) {
+                                blocksToCheck.add(adjacentPos);
+                            } else {
+                                attachedBlocks.put(adjacentPos, adjacentBlockId);
+                                blocksChecked.add(adjacentPos);
+                                blocksToCheck.add(adjacentPos.add(movement));
+                            }
+                        }
+                    }
+                }
+                // Check next block in line
+                blocksToCheck.add(blockPos.add(movement));
+            } else if (cannotDestroyBlock(blockId)) {
+                // Block can't be moved or destroyed, so it blocks all block movement
+                moveBlocks = false;
+                break;
+            }
+        }
+        if (!moveBlocks) {
+            attachedBlocks.clear();
+        }
+        flattenPositions();
+    }
+
+    private boolean canMoveBlock(int javaId, boolean isPushing) {
+        if (javaId == BlockTranslator.JAVA_AIR_ID) {
+            return true;
+        }
+        // Pistons can only be moved if they aren't extended
+        if (PistonBlockEntityTranslator.isBlock(javaId) && !isPistonHead(javaId)) {
+            return !BlockStateValues.getPistonValues().get(javaId);
+        }
+        // Bedrock, End portal frames, etc. can't be moved
+        if (BlockTranslator.JAVA_RUNTIME_ID_TO_HARDNESS.get(javaId) == -1.0d) {
+            return false;
+        }
+        String pistonBehavior = BlockTranslator.JAVA_RUNTIME_ID_TO_PISTON_BEHAVIOR.getOrDefault(javaId, "normal");
+        switch (pistonBehavior) {
+            case "block":
+            case "destroy":
+                return false;
+            case "push_only":
+                return isPushing;
+        }
+        // Pistons can't move block entities
+        return !BlockTranslator.JAVA_RUNTIME_ID_TO_HAS_BLOCK_ENTITY.getOrDefault(javaId, false);
+    }
+
+    private boolean cannotDestroyBlock(int javaId)  {
+        return !BlockTranslator.JAVA_RUNTIME_ID_TO_PISTON_BEHAVIOR.getOrDefault(javaId, "normal").equals("destroy");
+    }
+
+    /**
+     * Checks if a block sticks to other blocks.
+     * Slime and honey blocks.
+     * @param javaId The block id
+     * @return True if the block sticks to adjacent blocks
+     */
+    private boolean isBlockSticky(int javaId) {
+        return javaId == BlockTranslator.JAVA_RUNTIME_SLIME_BLOCK_ID || javaId == BlockTranslator.JAVA_RUNTIME_HONEY_BLOCK_ID;
+    }
+
+    /**
+     * Check if two blocks are attached to each other
+     * @param javaIdA The block id of block a
+     * @param javaIdB The block id of block b
+     * @return True if the blocks are attached to each other
+     */
+    private boolean isBlockAttached(int javaIdA, int javaIdB) {
+        boolean aSticky = isBlockSticky(javaIdA);
+        boolean bSticky = isBlockSticky(javaIdB);
+        if (aSticky && bSticky) {
+            // Only matching sticky blocks are attached together
+            // Honey + Honey & Slime + Slime
+            return javaIdA == javaIdB;
+        }
+        return aSticky || bSticky;
+    }
+
+    /**
+     * Get the direction the piston head points in
+     * @return A Vector3i pointing in the direction of the piston head
+     */
+    private Vector3i getDirectionOffset() {
+        switch (orientation) {
+            case DOWN:
+                return Vector3i.from(0, -1, 0);
+            case UP:
+                return Vector3i.from(0, 1, 0);
+            case SOUTH:
+                return Vector3i.from(0, 0, 1);
+            case WEST:
+                return Vector3i.from(-1, 0, 0);
+            case NORTH:
+                return Vector3i.from(0, 0, -1);
+            case EAST:
+                return Vector3i.from(1, 0, 0);
+        }
+        return Vector3i.ZERO;
+    }
+
+    /**
+     * Get the offset from the current position of the attached blocks
+     * to the new positions
+     * @return The movement of the blocks
+     */
+    private Vector3i getMovement() {
+        if (action == PistonValueType.PULLING) {
+            return getDirectionOffset().negate();
+        }
+        return getDirectionOffset(); // PUSHING and CANCELLED_MID_PUSH
+    }
+
+    /**
+     * Replace all attached blocks with air
+     */
+    private void removeBlocks() {
+        for (Vector3i blockPos : attachedBlocks.keySet()) {
+            ChunkUtils.updateBlock(session, BlockTranslator.JAVA_AIR_ID, blockPos);
+        }
+    }
+
+    private void correctPlayerPosition() {
+        BoundingBox playerBoundingBox = session.getCollisionManager().getPlayerBoundingBox();
+        BoundingBox playerCollision = new BoundingBox(playerBoundingBox.getMiddleX(), playerBoundingBox.getMiddleY(), playerBoundingBox.getMiddleZ(), playerBoundingBox.getSizeX(), playerBoundingBox.getSizeY(), playerBoundingBox.getSizeZ());
+
+        Vector3i direction = getDirectionOffset();
+        Vector3d movement = getMovement().toDouble();
+        Vector3d attachedBlockOffset = movement.mul(lastProgress);
+        if (action == PistonValueType.PULLING || action == PistonValueType.CANCELLED_MID_PUSH) {
+            attachedBlockOffset = movement.mul(1f - lastProgress);
+        }
+
+        double delta = Math.abs(progress - lastProgress);
+        Vector3d extend = movement.negate().mul(delta);
+        playerCollision.extend(extend.getX(), extend.getY(), extend.getZ());
+        // Shrink the collision in the other axes slightly, to avoid false positives when pressed up against the side of blocks
+        Vector3d shrink = Vector3i.from(1).sub(direction.abs()).toDouble().mul(CollisionManager.COLLISION_TOLERANCE * 2);
+        playerCollision.setSizeX(playerCollision.getSizeX() - shrink.getX());
+        playerCollision.setSizeY(playerCollision.getSizeY() - shrink.getY());
+        playerCollision.setSizeZ(playerCollision.getSizeZ() - shrink.getZ());
+
+        double displacement = 0;
+        // Check collision with the piston head
+        Vector3d blockPos = position.toDouble().add(attachedBlockOffset);
+        if (action == PistonValueType.PULLING) {
+            blockPos = blockPos.add(direction.toDouble());
+        }
+        // Use solid collision when pushing because the edge of the piston head is very thin
+        BlockCollision pistonCollision = SOLID_COLLISION;
+        if (action == PistonValueType.PULLING || action == PistonValueType.CANCELLED_MID_PUSH) {
+            int pistonHeadId = BlockStateValues.getPistonHead(orientation);
+            pistonCollision = CollisionTranslator.getCollision(pistonHeadId, 0, 0, 0);
+        }
+        double intersection = getBlockIntersection(blockPos, pistonCollision, playerCollision);
+        if (intersection > 0) {
+            intersection = Math.min(intersection, delta);
+            displacement = intersection + 0.01d;
+        }
+        // Check collision with all the attached blocks
+        for (Object2IntMap.Entry<Vector3i> entry : attachedBlocks.object2IntEntrySet()) {
+            blockPos = entry.getKey().toDouble().add(attachedBlockOffset);
+            int javaId = entry.getIntValue();
+            BlockCollision blockCollision = CollisionTranslator.getCollision(javaId, 0, 0, 0);
+            // Check if the player collides with the movingBlock block entity
+            Vector3d finalBlockPos = entry.getKey().toDouble().add(movement);
+            if (testBlockCollision(finalBlockPos, SOLID_COLLISION, playerCollision)) {
+                session.getPistonCache().setPlayerCollided(true);
+            }
+
+            if (javaId == BlockTranslator.JAVA_RUNTIME_SLIME_BLOCK_ID && testBlockCollision(blockPos, blockCollision, playerCollision)) {
+                Vector3d playerPos = Vector3d.from(playerCollision.getMiddleX(), playerCollision.getMiddleY(), playerCollision.getMiddleZ());
+                playerPos = playerPos.add(movement.mul(displacement));
+                applySlimeBlockMotion(blockPos.add(0.5, 0.5, 0.5), playerPos);
+            }
+
+            if (javaId == BlockTranslator.JAVA_RUNTIME_HONEY_BLOCK_ID && isPlayerAttached(blockPos, playerBoundingBox)) {
+                displacement = Math.max(delta, displacement);
+            } else if (displacement < 0.51d) { // Don't bother to check collision with other blocks as we've reached the max displacement
+                intersection = getBlockIntersection(blockPos, blockCollision, playerCollision);
+                if (intersection > 0) {
+                    intersection = Math.min(intersection, delta);
+                    displacement = Math.max(intersection + 0.01d, displacement);
+                }
+            }
+        }
+        if (displacement > 0) {
+            Vector3d totalDisplacement = session.getPistonCache().getPlayerDisplacement().add(movement.mul(displacement));
+            // Clamp to range -0.51 to 0.51
+            totalDisplacement = totalDisplacement.max(-0.51d, -0.51d, -0.51d).min(0.51d, 0.51d, 0.51d);
+            session.getPistonCache().setPlayerDisplacement(totalDisplacement);
+
+            Vector3d position = session.getPlayerEntity().getPosition().down(EntityType.PLAYER.getOffset()).toDouble();
+            position = position.add(totalDisplacement);
+            session.getCollisionManager().updatePlayerBoundingBox(position);
+        }
+    }
+
+    /**
+     * Checks if a player is attached to the top of a honey block.
+     * @param blockPos The position of the honey block.
+     * @param playerBoundingBox The player's bounding box.
+     * @return True if the player attached, otherwise false
+     */
+    private boolean isPlayerAttached(Vector3d blockPos, BoundingBox playerBoundingBox) {
+        if (orientation == PistonValue.UP || orientation == PistonValue.DOWN) {
+            return false;
+        }
+        return session.getPlayerEntity().isOnGround() && HONEY_BOUNDING_BOX.checkIntersection(blockPos.getX(), blockPos.getY(), blockPos.getZ(), playerBoundingBox);
+    }
+
+    private boolean testBlockCollision(Vector3d blockPos, BlockCollision blockCollision, BoundingBox playerCollision) {
+        if (blockCollision != null) {
+            BoundingBox blockBoundingBox = blockCollision.getContainingBoundingBox();
+            return blockBoundingBox != null && blockBoundingBox.checkIntersection(blockPos.getX(), blockPos.getY(), blockPos.getZ(), playerCollision);
+        }
+        return false;
+    }
+
+    /**
+     * Launches a player if the player is on the pushing side of the slime block
+     * @param blockPos Position of the slime block
+     * @param playerPos The player's position
+     */
+    private void applySlimeBlockMotion(Vector3d blockPos, Vector3d playerPos) {
+        PistonValue movementDirection = orientation;
+        // Invert direction when pulling
+        if (action == PistonValueType.PULLING) {
+            switch (movementDirection) {
+                case DOWN:
+                    movementDirection = PistonValue.UP;
+                    break;
+                case UP:
+                    movementDirection = PistonValue.DOWN;
+                    break;
+                case NORTH:
+                    movementDirection = PistonValue.SOUTH;
+                    break;
+                case SOUTH:
+                    movementDirection = PistonValue.NORTH;
+                    break;
+                case WEST:
+                    movementDirection = PistonValue.EAST;
+                    break;
+                case EAST:
+                    movementDirection = PistonValue.WEST;
+                    break;
+            }
+        }
+
+        Vector3f movement = getMovement().toFloat();
+        Vector3f motion = session.getPistonCache().getPlayerMotion();
+        double motionX = motion.getX();
+        double motionY = motion.getY();
+        double motionZ = motion.getZ();
+        switch (movementDirection) {
+            case DOWN:
+                if (playerPos.getY() < blockPos.getY()) {
+                    motionY = movement.getY();
+                }
+                break;
+            case UP:
+                if (playerPos.getY() > blockPos.getY()) {
+                    motionY = movement.getY();
+                }
+                break;
+            case NORTH:
+                if (playerPos.getZ() < blockPos.getZ()) {
+                    motionZ = movement.getZ();
+                }
+                break;
+            case SOUTH:
+                if (playerPos.getZ() > blockPos.getZ()) {
+                    motionZ = movement.getZ();
+                }
+                break;
+            case WEST:
+                if (playerPos.getX() < blockPos.getX()) {
+                    motionX = movement.getX();
+                }
+                break;
+            case EAST:
+                if (playerPos.getX() > blockPos.getX()) {
+                    motionX = movement.getX();
+                }
+                break;
+        }
+        session.getPistonCache().setPlayerMotion(Vector3f.from(motionX, motionY, motionZ));
+    }
+
+    private double getBlockIntersection(Vector3d blockPos, BlockCollision blockCollision, BoundingBox playerCollision) {
+        if (!testBlockCollision(blockPos, blockCollision, playerCollision)) {
+            return 0;
+        }
+        double maxIntersection = 0;
+        for (BoundingBox b : blockCollision.getBoundingBoxes()) {
+            Vector3d intersectionSize = b.getIntersectionSize(blockPos.getX(), blockPos.getY(), blockPos.getZ(), playerCollision);
+            switch (orientation) {
+                case DOWN:
+                case UP:
+                    maxIntersection = Math.max(intersectionSize.getY(), maxIntersection);
+                    break;
+                case NORTH:
+                case SOUTH:
+                    maxIntersection = Math.max(intersectionSize.getZ(), maxIntersection);
+                    break;
+                case WEST:
+                case EAST:
+                    maxIntersection = Math.max(intersectionSize.getX(), maxIntersection);
+                    break;
+            }
+        }
+        return maxIntersection;
+    }
+
+    /**
+     * Create moving block entities for each attached block
+     */
+    private void createMovingBlocks() {
+        Vector3i movement = getMovement();
+        attachedBlocks.forEach((blockPos, javaId) -> {
+            Vector3i newPos = blockPos.add(movement);
+            // Place a moving block at the new location of the block
+            UpdateBlockPacket updateBlockPacket = new UpdateBlockPacket();
+            updateBlockPacket.getFlags().add(UpdateBlockPacket.Flag.NEIGHBORS);
+            updateBlockPacket.getFlags().add(UpdateBlockPacket.Flag.NETWORK);
+            updateBlockPacket.setBlockPosition(newPos);
+            updateBlockPacket.setRuntimeId(BlockTranslator.BEDROCK_RUNTIME_MOVING_BLOCK_ID);
+            updateBlockPacket.setDataLayer(0);
+            session.sendUpstreamPacket(updateBlockPacket);
+            // Update moving block with correct details
+            BlockEntityUtils.updateBlockEntity(session, buildMovingBlockTag(newPos, javaId, position), newPos);
+        });
+    }
+
+    /**
+     * Replace all moving block entities with the final block
+     */
+    private void finishMovingBlocks() {
+        Vector3i movement = getMovement();
+        attachedBlocks.forEach((blockPos, javaId) -> {
+            blockPos = blockPos.add(movement);
+            // Send a final block entity packet to detach blocks
+            BlockEntityUtils.updateBlockEntity(session, buildMovingBlockTag(blockPos, javaId, Vector3i.from(0, -1, 0)), blockPos);
+            // Replace with final block
+            ChunkUtils.updateBlock(session, javaId, blockPos);
+            // Send piston block entity data
+            if (PistonBlockEntityTranslator.isBlock(javaId)) {
+                BlockEntityUtils.updateBlockEntity(session, PistonBlockEntityTranslator.getTag(javaId, blockPos), blockPos);
+            }
+        });
+    }
+
+    /**
+     * Flatten the positions of attached blocks into a 1D array
+     */
+    private void flattenPositions() {
+        flattenedAttachedBlocks = new int[3 * attachedBlocks.size()];
+        Iterator<Vector3i> attachedBlocksIterator = attachedBlocks.keySet().iterator();
+        int i = 0;
+        while (attachedBlocksIterator.hasNext()) {
+            Vector3i position = attachedBlocksIterator.next();
+            flattenedAttachedBlocks[3 * i] = position.getX();
+            flattenedAttachedBlocks[3 * i + 1] = position.getY();
+            flattenedAttachedBlocks[3 * i + 2] = position.getZ();
+            i++;
+        }
+    }
+
+    /**
+     * Get the Bedrock state of the piston
+     * @return 0 - Fully retracted, 1 - Extending, 2 - Fully extended, 3 - Retracting
+     */
+    private byte getState() {
+        switch (action) {
+            case PUSHING:
+                return (byte) (isDone() ? 2 : 1);
+            case PULLING:
+                return (byte) (isDone() ? 0 : 3);
+            default:
+                if (progress == 1.0f) {
+                    return 2;
+                }
+                return (byte) (isDone() ? 0 : 2);
+        }
+    }
+
+    /**
+     * Update the progress or position of the piston head
+     */
+    private void updateProgress() {
+        switch (action) {
+            case PUSHING:
+                lastProgress = progress;
+                progress += 0.5f;
+                if (progress >= 1.0f) {
+                    progress = 1.0f;
+                }
+                break;
+            case CANCELLED_MID_PUSH:
+            case PULLING:
+                lastProgress = progress;
+                progress -= 0.5f;
+                if (progress <= 0.0f) {
+                    progress = 0.0f;
+                }
+                break;
+        }
+    }
+
+    /**
+     * @return True if the piston has finished it's movement, otherwise false
+     */
+    public boolean isDone() {
+        switch (action) {
+            case PUSHING:
+                return progress == 1.0f && lastProgress == 1.0f;
+            case PULLING:
+            case CANCELLED_MID_PUSH:
+                return progress == 0.0f && lastProgress == 0.0f;
+        }
+        return true;
+    }
+
+    /**
+     * Create a piston data tag with the data in this block entity
+     * @return A piston data tag
+     */
+    private NbtMap buildPistonTag() {
+        NbtMapBuilder builder = NbtMap.builder()
+                .putString("id", "PistonArm")
+                .putIntArray("AttachedBlocks", flattenedAttachedBlocks)
+                .putFloat("Progress", progress)
+                .putFloat("LastProgress", lastProgress)
+                .putByte("NewState", getState())
+                .putByte("State", getState())
+                .putByte("Sticky", (byte) (sticky ? 1 : 0))
+                .putByte("isMovable", (byte) 0)
+                .putInt("x", position.getX())
+                .putInt("y", position.getY())
+                .putInt("z", position.getZ());
+        return builder.build();
+    }
+
+    /**
+     * Create a piston data tag that has fully extended/retracted
+     * @param position The position for the base of the piston
+     * @param extended If the piston is extended or not
+     * @param sticky If the piston is a sticky piston or not
+     * @return A piston data tag for a fully extended/retracted piston
+     */
+    public static NbtMap buildStaticPistonTag(Vector3i position, boolean extended, boolean sticky) {
+        NbtMapBuilder builder = NbtMap.builder()
+                .putString("id", "PistonArm")
+                .putFloat("Progress", extended ? 1.0f : 0.0f)
+                .putFloat("LastProgress", extended ? 1.0f : 0.0f)
+                .putByte("NewState", (byte) (extended ? 2 : 0))
+                .putByte("State", (byte) (extended ? 2 : 0))
+                .putByte("Sticky", (byte) (sticky ? 1 : 0))
+                .putByte("isMovable", (byte) 0)
+                .putInt("x", position.getX())
+                .putInt("y", position.getY())
+                .putInt("z", position.getZ());
+        return builder.build();
+    }
+
+    /**
+     * Create a moving block tag of a block that will be moved by a piston
+     * @param position The ending position of the block
+     * @param javaId The Java Id of the block that is moving
+     * @param pistonPosition The position for the base of the piston that's moving the block
+     * @return A moving block data tag
+     */
+    private NbtMap buildMovingBlockTag(Vector3i position, int javaId, Vector3i pistonPosition) {
+        // Get Bedrock block state data
+        NbtMap movingBlock = BlockTranslator.BLOCKS.get(BlockTranslator.getBedrockBlockId(javaId)).getCompound("block");
+        NbtMapBuilder builder = NbtMap.builder()
+                .putString("id", "MovingBlock")
+                .putCompound("movingBlock", movingBlock)
+                .putCompound("movingBlockExtra", AIR_TAG) //TODO figure out if this changes
+                .putByte("isMovable", (byte) 1)
+                .putInt("pistonPosX", pistonPosition.getX())
+                .putInt("pistonPosY", pistonPosition.getY())
+                .putInt("pistonPosZ", pistonPosition.getZ())
+                .putInt("x", position.getX())
+                .putInt("y", position.getY())
+                .putInt("z", position.getZ());
+        if (PistonBlockEntityTranslator.isBlock(javaId)) {
+            builder.putCompound("movingEntity", PistonBlockEntityTranslator.getTag(javaId, position));
+        }
+        return builder.build();
+    }
+}

--- a/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/PistonBlockEntityTranslator.java
+++ b/connector/src/main/java/org/geysermc/connector/network/translators/world/block/entity/PistonBlockEntityTranslator.java
@@ -27,7 +27,6 @@ package org.geysermc.connector.network.translators.world.block.entity;
 
 import com.nukkitx.math.vector.Vector3i;
 import com.nukkitx.nbt.NbtMap;
-import com.nukkitx.nbt.NbtMapBuilder;
 import org.geysermc.connector.network.translators.world.block.BlockStateValues;
 
 /**
@@ -52,19 +51,8 @@ public class PistonBlockEntityTranslator {
      * @return Bedrock tag of piston.
      */
     public static NbtMap getTag(int blockState, Vector3i position) {
-        NbtMapBuilder tagBuilder = NbtMap.builder()
-                .putInt("x", position.getX())
-                .putInt("y", position.getY())
-                .putInt("z", position.getZ())
-                .putByte("isMovable", (byte) 1)
-                .putString("id", "PistonArm");
-
         boolean extended = BlockStateValues.getPistonValues().get(blockState);
-        // 1f if extended, otherwise 0f
-        tagBuilder.putFloat("Progress", (extended) ? 1.0f : 0.0f);
-        // 1 if sticky, 0 if not
-        tagBuilder.putByte("Sticky", (byte) ((BlockStateValues.isStickyPiston(blockState)) ? 1 : 0));
-
-        return tagBuilder.build();
+        boolean sticky = BlockStateValues.isStickyPiston(blockState);
+        return PistonBlockEntity.buildStaticPistonTag(position, extended, sticky);
     }
 }

--- a/connector/src/main/java/org/geysermc/connector/utils/DimensionUtils.java
+++ b/connector/src/main/java/org/geysermc/connector/utils/DimensionUtils.java
@@ -66,6 +66,7 @@ public class DimensionUtils {
 
         session.getEntityCache().removeAllEntities();
         session.getItemFrameCache().clear();
+        session.getPistonCache().clear();
         session.getSkullCache().clear();
         if (session.getPendingDimSwitches().getAndIncrement() > 0) {
             ChunkUtils.sendEmptyChunks(session, player.getPosition().toInt(), 3, true);


### PR DESCRIPTION
* Add PistonBlockEntity and cache it

* Move blocks smoothly

* Edit comments & add additional checks for adjacent blocks
Fix moving pistons

* Fix phantom piston heads and sticky block handling

* Fix buggy moving pistons

* Add check for sticky pistons when pulling

* Change default piston behavior to normal

* Changes for 1.16.100

* Update mappings

* Add collision helper functions

* Somewhat fix pistons pushing players

* Send SetEntityMotion Packet to launch players on Slime blocks

* Check collision with piston head + send corrected pos to server

* Shrink player collision slightly

* Only call collisionManager.correctPlayerPosition once

* Use runtime ids to check for slime and honey blocks

* Add movement for standing on honey blocks

* Hopefully fix out of bounds exception

* Move PISTON_HEADS to BlockStateValues

* Improve pistons pushing players some more

* Remove fixDirection

* Fix timing

* Clean up and fix pushing destroyed blocks

* Launch players only on the pushing side of slime

* Improve player pushing and launching

* Fix motion check

* Add honey check and add some comments

* Cancel movement when colliding with movingBlock

* Prevent piston from moving block entities

Co-authored-by: David Choo <davchoo3@gmail.com>